### PR TITLE
Update parent-child check to avoid panic

### DIFF
--- a/cadence/scripts/hybrid_custody/is_parent.cdc
+++ b/cadence/scripts/hybrid_custody/is_parent.cdc
@@ -2,8 +2,7 @@ import "HybridCustody"
 
 pub fun main(child: Address, parent: Address): Bool {
     let acct = getAuthAccount(child)
-    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
-        ?? panic("owned account not found")
-
-    return owned.isChildOf(parent)
+    return acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        ?.isChildOf(parent)
+        ?? false
 }

--- a/packages/shared/cadence/scripts/hybrid-custody/is_child_account_of.ts
+++ b/packages/shared/cadence/scripts/hybrid-custody/is_child_account_of.ts
@@ -3,10 +3,9 @@ import HybridCustody from 0xHybridCustody
 
 pub fun main(child: Address, parent: Address): Bool {
     let acct = getAuthAccount(child)
-    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
-        ?? panic("owned account not found")
-
-    return owned.isChildOf(parent)
+    return acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        ?.isChildOf(parent)
+        ?? false
 }
 `
 export default IS_CHILD_ACCOUNT_OF


### PR DESCRIPTION
Currently, panicking in this query results in unrecoverable behavior. Instead, we'll recover gracefully and return `false`.